### PR TITLE
Fixed missing command arguements in entrypoint.

### DIFF
--- a/assets/entrypoint.sh.templ
+++ b/assets/entrypoint.sh.templ
@@ -12,4 +12,4 @@ if [[ -n "${{ .EnvVar }}" ]]; then
     {{- end }}
 fi
 {{ end }}
-exec $COMMAND
+exec $COMMAND "${PLUGIN_COMMAND_ARGUMENTS}"


### PR DESCRIPTION
This commit adds COMMAND_ARGUEMENTS to the entrypoint so that a list of command
arguements that fpm expects can be used in the plugin.